### PR TITLE
Updates to build the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     apt-get -y install wget gnupg && \
     echo "deb http://dl.winehq.org/wine-builds/debian/ stretch main" >> \
       /etc/apt/sources.list.d/winehq.list && \
-    wget http://dl.winehq.org/wine-builds/Release.key -qO- | apt-key add - && \
+    wget http://dl.winehq.org/wine-builds/winehq.key -qO- | apt-key add - && \
     apt-get update && \
     apt-get -y --install-recommends install \
       bzip2 unzip curl \


### PR DESCRIPTION
I included several updates to create a successful build of the container. 

**WineHQ** https://github.com/phnmnl/container-pwiz/commit/f6b81051475734ccb14fb2f96b99789641a1fc36:
The repository changed the path to the keyfile. Without this change, apt refuses to install wine at all.
**Teamcity**
The Rest-API of Teamcity changed. In addition, it is not possible to install old builds anymore, because not all old artefacts are available to guests. The script fetches the most recent version now. 
